### PR TITLE
Added ContainsKey and TryGetValue methods

### DIFF
--- a/src/Calendar.Plugin/Shared/Models/EventCollection.cs
+++ b/src/Calendar.Plugin/Shared/Models/EventCollection.cs
@@ -96,6 +96,18 @@ namespace Xamarin.Plugin.Calendar.Models
         {
             return base.TryGetValue(key.Date, out value);
         }
+        
+        /// <summary>
+        /// Removes all dates and collections
+        /// </summary>
+        public new void Clear()
+        {
+            if (base.Count == 0)
+                return;
+
+            base.Clear();
+            CollectionChanged?.Invoke(this, new EventCollectionChangedArgs {Item = default(DateTime), Type = EventCollectionChangedType.Clear});
+        }
 
         internal event EventHandler<EventCollectionChangedArgs> CollectionChanged;
 
@@ -109,7 +121,8 @@ namespace Xamarin.Plugin.Calendar.Models
         {
             Add,
             Set,
-            Remove
+            Remove,
+            Clear
         }
     }
 }

--- a/src/Calendar.Plugin/Shared/Models/EventCollection.cs
+++ b/src/Calendar.Plugin/Shared/Models/EventCollection.cs
@@ -75,6 +75,27 @@ namespace Xamarin.Plugin.Calendar.Models
                 CollectionChanged?.Invoke(this, new EventCollectionChangedArgs { Item = key.Date, Type = EventCollectionChangedType.Set });
             }
         }
+        
+        /// <summary>
+        /// Checks if dictionary already has collection for specific date
+        /// </summary>
+        /// <param name="key">Key DateTime</param>
+        /// <returns>true if dictionary already has the date as key; otherwise, false</returns>
+        public new bool ContainsKey(DateTime key)
+        {
+            return base.ContainsKey(key.Date);
+        }
+
+        /// <summary>
+        /// Gets the value associated with the specific date
+        /// </summary>
+        /// <param name="key">The date for the value to get</param>
+        /// <param name="value">If the date exists then this is the associated collection; otherwise, it will be the default value of ICollection</param>
+        /// <returns>true if dictionary contains an element with the specified date; otherwise false</returns>
+        public new bool TryGetValue(DateTime key, out ICollection value)
+        {
+            return base.TryGetValue(key.Date, out value);
+        }
 
         internal event EventHandler<EventCollectionChangedArgs> CollectionChanged;
 


### PR DESCRIPTION
I've added ContainsKey and TryGetValue methods to the EventCollection to reduce confusion when using the base Dictionary methods on the EventCollection. Previously these methods would check the whole DateTime, instead of only using the date, as the EventCollection does.