### PR TITLE
Added date range selection capability

### DIFF
--- a/src/Calendar.Plugin.Sample/SampleApp.Android/SampleApp.Android.csproj
+++ b/src/Calendar.Plugin.Sample/SampleApp.Android/SampleApp.Android.csproj
@@ -15,7 +15,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
@@ -53,9 +52,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Rg.Plugins.Popup">
-      <Version>1.2.0.223</Version>
+      <Version>2.0.0.3</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.356" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.3" />
@@ -63,6 +61,9 @@
     <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="28.0.0.3" />
+    <PackageReference Include="Xamarin.Forms">
+      <Version>4.8.0.1269</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
@@ -104,7 +105,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SampleApp\SampleApp.csproj">
-      <Project>{E4FB5119-AAD4-43E4-8741-1759FAF4083B}</Project>
+      <Project>{C269E453-794E-4A6F-AAB0-D13865588FD7}</Project>
       <Name>SampleApp</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/Calendar.Plugin.Sample/SampleApp.iOS/SampleApp.iOS.csproj
+++ b/src/Calendar.Plugin.Sample/SampleApp.iOS/SampleApp.iOS.csproj
@@ -163,9 +163,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Rg.Plugins.Popup">
-      <Version>1.2.0.223</Version>
+      <Version>2.0.0.3</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.356" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
@@ -176,7 +176,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SampleApp\SampleApp.csproj">
-      <Project>{E4FB5119-AAD4-43E4-8741-1759FAF4083B}</Project>
+      <Project>{C269E453-794E-4A6F-AAB0-D13865588FD7}</Project>
       <Name>SampleApp</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/Calendar.Plugin.Sample/SampleApp/SampleApp.csproj
+++ b/src/Calendar.Plugin.Sample/SampleApp/SampleApp.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rg.Plugins.Popup" Version="1.2.0.223" />
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.356" />
+    <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.3" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Calendar.Plugin.Sample/SampleApp/ViewModels/SimplePageViewModel.cs
+++ b/src/Calendar.Plugin.Sample/SampleApp/ViewModels/SimplePageViewModel.cs
@@ -108,6 +108,21 @@ namespace SampleApp.ViewModels
             set => SetProperty(ref _maximumDate, value);
         }
 
+        private DateTime? _rangeStart = DateTime.Today.AddDays(5);
+        public DateTime? RangeStart
+        {
+            get => _rangeStart;
+            set => SetProperty(ref _rangeStart, value);
+        }
+
+        private DateTime? _rangeEnd = DateTime.Today.AddDays(13);
+        public DateTime? RangeEnd
+        {
+            get => _rangeEnd;
+            set => SetProperty(ref _rangeEnd, value);
+        }
+
+
         private async Task ExecuteEventSelectedCommand(object item)
         {
             if(item is EventModel eventModel)

--- a/src/Calendar.Plugin.Sample/SampleApp/Views/SimplePage.xaml
+++ b/src/Calendar.Plugin.Sample/SampleApp/Views/SimplePage.xaml
@@ -24,7 +24,11 @@
         Month="{Binding Month}"
         SelectedDate="{Binding SelectedDate}"
         VerticalOptions="FillAndExpand"
-        Year="{Binding Year}">
+        Year="{Binding Year}"
+        RangeSelectionEnabled="False"
+        RangeSelectionStartDate="{Binding RangeStart}"
+        RangeSelectionEndDate="{Binding RangeEnd}"
+        >
 
         <plugin:Calendar.EventTemplate>
             <DataTemplate>

--- a/src/Calendar.Plugin/CalendarPlugin.csproj
+++ b/src/Calendar.Plugin/CalendarPlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;MonoAndroid90;Xamarin.iOS10</TargetFrameworks>
     <Authors>Josip Caleta</Authors>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <PackageId>Xamarin.Plugin.Calendar</PackageId>
@@ -48,7 +48,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
     <Compile Include="Shared\**\*.cs" />
   </ItemGroup>
 

--- a/src/Calendar.Plugin/Shared/Controls/Calendar.xaml
+++ b/src/Calendar.Plugin/Shared/Controls/Calendar.xaml
@@ -57,6 +57,9 @@
                     SelectedDayTextColor="{Binding SelectedDayTextColor, Source={x:Reference calendar}}"
                     TodayFillColor="{Binding TodayFillColor, Source={x:Reference calendar}}"
                     TodayOutlineColor="{Binding TodayOutlineColor, Source={x:Reference calendar}}"
+                    RangeSelectionEnabled="{Binding RangeSelectionEnabled, Source={x:Reference calendar}}"
+                    RangeSelectionStartDate="{Binding RangeSelectionStartDate, Source={x:Reference calendar}}"
+                    RangeSelectionEndDate="{Binding RangeSelectionEndDate, Source={x:Reference calendar}}"
                     VerticalOptions="FillAndExpand" />
             </controls:SwipeAwareContainer>
         </StackLayout>

--- a/src/Calendar.Plugin/Shared/Controls/Calendar.xaml.cs
+++ b/src/Calendar.Plugin/Shared/Controls/Calendar.xaml.cs
@@ -507,6 +507,37 @@ namespace Xamarin.Plugin.Calendar.Controls
             set => SetValue(AnimateCalendarProperty, value);
         }
 
+
+        #region Range Selection
+        public static readonly BindableProperty RangeSelectionStartDateProperty =
+          BindableProperty.Create(nameof(RangeSelectionStartDate), typeof(DateTime?), typeof(Calendar), null, BindingMode.TwoWay);
+
+        public DateTime? RangeSelectionStartDate
+        {
+            get => (DateTime?)GetValue(RangeSelectionStartDateProperty);
+            set => SetValue(RangeSelectionStartDateProperty, value);
+        }
+
+
+        public static readonly BindableProperty RangeSelectionEndDateProperty =
+          BindableProperty.Create(nameof(RangeSelectionEndDate), typeof(DateTime?), typeof(Calendar), null, BindingMode.TwoWay);
+
+        public DateTime? RangeSelectionEndDate
+        {
+            get => (DateTime?)GetValue(RangeSelectionEndDateProperty);
+            set => SetValue(RangeSelectionEndDateProperty, value);
+        }
+
+
+        public static readonly BindableProperty RangeSelectionEnabledProperty =
+            BindableProperty.Create(nameof(RangeSelectionEnabled), typeof(bool), typeof(Calendar), false);
+
+        public bool RangeSelectionEnabled
+        {
+            get => (bool)GetValue(RangeSelectionEnabledProperty);
+            set => SetValue(RangeSelectionEnabledProperty, value);
+        }
+        #endregion
         #endregion
 
         private const uint CalendarSectionAnimationRate = 16;


### PR DESCRIPTION
Users can now enable range selection on the calendar, which allows them to select a range of days instead of one day only, by selecting a start date followed by an end date. All days in between (and including) those days will be marked selected.
This can be useful for booking applications where users are required to select a start and end day, without needing to open two separate calendars for each day.

To enable, set `RangeSelectionEnabled` to `True` in your calendar control, and optionally, set the `RangeSelectionStartDate` and `RangeSelectionEndDate` properties.

![Simulator Screen Shot - iPhone 11 - 2020-08-26 at 23 02 05](https://user-images.githubusercontent.com/46938523/91365264-396f8a80-e7f0-11ea-84c7-7a44f5979d13.png)
