### PR TITLE
Culture abbreviated day name length fix

### DIFF
--- a/src/Calendar.Plugin/Shared/Controls/MonthDaysView.xaml.cs
+++ b/src/Calendar.Plugin/Shared/Controls/MonthDaysView.xaml.cs
@@ -385,7 +385,8 @@ namespace Xamarin.Plugin.Calendar.Controls
 
             foreach (var dayLabel in daysTitleControl.Children.OfType<Label>())
             {
-                dayLabel.Text = Culture.DateTimeFormat.AbbreviatedDayNames[dayNumber].ToUpper().Substring(0, (int)DaysTitleMaximumLength);
+                var abberivatedDayName = Culture.DateTimeFormat.AbbreviatedDayNames[dayNumber];
+                dayLabel.Text = abberivatedDayName.ToUpper().Substring(0, (int)DaysTitleMaximumLength > abberivatedDayName.Length ? abberivatedDayName.Length: (int)DaysTitleMaximumLength);
                 dayNumber = (dayNumber + 1) % 7;
             }
         }


### PR DESCRIPTION
For each day we check the abberivatedDayName.Length and if its smaller then three we take his length.