### PR TITLE
Ensure that the GestureDetector is disposed

### DIFF
--- a/src/Calendar.Plugin/Android/SwipeAwareContainerRenderer.cs
+++ b/src/Calendar.Plugin/Android/SwipeAwareContainerRenderer.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Plugin.Calendar.Android
         private const int SwipeDistanceThreshold = 50;
         private const int SwipeVelocityThreshold = 20;
         private readonly GestureDetector _gestureDetector;
-        private bool _isDisposed;
+        private bool _isDisposed = false;
 
         public SwipeAwareContainerRenderer(Context context) : base(context)
         {

--- a/src/Calendar.Plugin/Android/SwipeAwareContainerRenderer.cs
+++ b/src/Calendar.Plugin/Android/SwipeAwareContainerRenderer.cs
@@ -13,8 +13,8 @@ namespace Xamarin.Plugin.Calendar.Android
     {
         private const int SwipeDistanceThreshold = 50;
         private const int SwipeVelocityThreshold = 20;
-        private readonly GestureDetector _gestureDetector;
-        private bool _isDisposed = false;
+        private GestureDetector _gestureDetector;
+        private bool _isDisposed;
 
         public SwipeAwareContainerRenderer(Context context) : base(context)
         {

--- a/src/Calendar.Plugin/Android/SwipeAwareContainerRenderer.cs
+++ b/src/Calendar.Plugin/Android/SwipeAwareContainerRenderer.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Plugin.Calendar.Android
         private const int SwipeDistanceThreshold = 50;
         private const int SwipeVelocityThreshold = 20;
         private readonly GestureDetector _gestureDetector;
+        private bool _isDisposed;
 
         public SwipeAwareContainerRenderer(Context context) : base(context)
         {
@@ -22,6 +23,9 @@ namespace Xamarin.Plugin.Calendar.Android
 
         public override bool OnInterceptTouchEvent(MotionEvent ev)
         {
+            if (_isDisposed)
+                return false;
+        
             if (Element is SwipeAwareContainer element && !element.SwipeDetectionDisabled)
                 _gestureDetector.OnTouchEvent(ev);
 
@@ -63,6 +67,25 @@ namespace Xamarin.Plugin.Calendar.Android
 
             return false;
         }
+        
+        protected override void Dispose(bool disposing)
+        {
+            if (_isDisposed)
+                return;
+
+            _isDisposed = true;
+
+            if (disposing)
+            {
+                if (_gestureDetector != null)
+                {
+                    _gestureDetector.Dispose();
+                    _gestureDetector = null;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
 
         #region Unused gestures
 
@@ -73,6 +96,5 @@ namespace Xamarin.Plugin.Calendar.Android
         public bool OnSingleTapUp(MotionEvent e) => false;
 
         #endregion
-
     }
 }


### PR DESCRIPTION
I received a log from a crash of my app that is related to the SwipeAwareContainerRenderer class used by the calendar.
From the stacktrace the crash seem to be caused by a press that try to access the renderer, but it has already been disposed so it crash the application.
I think the solution is to force the dispose of the gesture detector to prevent that, not sure if this will be enough but it's a good start.

FYI, the stacktrace of the crash
```cs
System.NotSupportedException: Unable to activate instance of type Xamarin.Plugin.Calendar.Android.SwipeAwareContainerRenderer from native handle 0xffc46fdc (key_handle 0xe4b6c0a).
  at IJavaPeerable Java.Interop.TypeManager.CreateInstance(IntPtr handle, JniHandleOwnership transfer, Type targetType)
  at IJavaPeerable Java.Lang.Object.GetObject(IntPtr handle, JniHandleOwnership transfer, Type type)
  at IOnGestureListener Java.Lang.Object._GetObject<IOnGestureListener>(IntPtr handle, JniHandleOwnership transfer)
  at IOnGestureListener Java.Lang.Object.GetObject<IOnGestureListener>(IntPtr handle, JniHandleOwnership transfer) x 2
  at void Android.Views.GestureDetector+IOnGestureListenerInvoker.n_OnLongPress_Landroid_view_MotionEvent_(IntPtr jnienv, IntPtr native__this, IntPtr native_e)
--- End of inner exception stack trace ---
  System.MissingMethodException: No constructor found for Xamarin.Plugin.Calendar.Android.SwipeAwareContainerRenderer::.ctor(System.IntPtr, Android.Runtime.JniHandleOwnership)
    at object Java.Interop.TypeManager.CreateProxy(Type type, IntPtr handle, JniHandleOwnership transfer)
    at IJavaPeerable Java.Interop.TypeManager.CreateInstance(IntPtr handle, JniHandleOwnership transfer, Type targetType)
```