### PR TITLE
Fix month view start date

### DIFF
--- a/src/Calendar.Plugin/Shared/Controls/Calendar.xaml.cs
+++ b/src/Calendar.Plugin/Shared/Controls/Calendar.xaml.cs
@@ -962,7 +962,7 @@ namespace Xamarin.Plugin.Calendar.Controls
         private readonly Animation _calendarSectionAnimateShow;
         private bool _calendarSectionAnimating;
         private double _calendarSectionHeight;
-        private IViewLayoutEngine _viewLayoutEngine = new MonthViewEngine(CultureInfo.InvariantCulture);
+        private IViewLayoutEngine _viewLayoutEngine;
 
         /// <summary>
         /// Calendar plugin for Xamarin.Forms
@@ -976,6 +976,8 @@ namespace Xamarin.Plugin.Calendar.Controls
             ShowHideCalendarCommand = new Command(ToggleCalendarSectionVisibility);
 
             InitializeComponent();
+
+            InitializeViewLayoutEngine();
             InitializeSelectionType();
             UpdateSelectedDateLabel();
             UpdateLayoutUnitLabel();
@@ -985,6 +987,11 @@ namespace Xamarin.Plugin.Calendar.Controls
             _calendarSectionAnimateShow = new Animation(AnimateMonths, 0, 1);
 
             calendarContainer.SizeChanged += OnCalendarContainerSizeChanged;
+        }
+
+        private void InitializeViewLayoutEngine()
+        {
+            _viewLayoutEngine = new MonthViewEngine(Culture);
         }
 
         private void InitializeSelectionType()

--- a/src/Calendar.Plugin/Shared/Controls/MonthDaysView.cs
+++ b/src/Calendar.Plugin/Shared/Controls/MonthDaysView.cs
@@ -569,7 +569,7 @@ namespace Xamarin.Plugin.Calendar.Controls
                     break;
 
                 case nameof(Culture):
-                    UpdateDayTitles();
+                    RenderLayout();
                     UpdateAndAnimateDays(AnimateCalendar);
                     break;
 


### PR DESCRIPTION
Fix another regression from PR #106.
If you want to use a culture with a different week start day than the invariant culture, the calendar days and headers are shifted by one.

Two problems here :
- The first is that the view engine in the calendar was initialized with invariant culture, the culture of the calendar was ignored
- The second is in MonthDaysView, as the properties are sorted in alphabetical order in the view, the CalendarLayout is initialized before the Culture, so when the culture is loaded the layout has already be done, so redone it to ensure that the right culture is used.