### PR TITLE
Ensure that the day is inside a valid range when month change

### DIFF
--- a/src/Calendar.Plugin/Shared/Controls/Calendar.xaml.cs
+++ b/src/Calendar.Plugin/Shared/Controls/Calendar.xaml.cs
@@ -1055,7 +1055,7 @@ namespace Xamarin.Plugin.Calendar.Controls
                 throw new ArgumentException("Month must be between 1 and 12.");
 
             if (bindable is Calendar calendar && calendar.ShownDate.Month != newMonth)
-                calendar.ShownDate = new DateTime(calendar.Year, newMonth, calendar.Day);
+                calendar.ShownDate = new DateTime(calendar.Year, newMonth, Math.Min(DateTime.DaysInMonth(calendar.Year, newMonth), calendar.Day));
         }
 
         private static void OnDayChanged(BindableObject bindable, object oldValue, object newValue)


### PR DESCRIPTION
When only the month is changed and that the current date is end of month, like 31 January to February. It can generate an out of range date resulting in an app crash.
Ensure that the day is not greater than the last day of the new month before creating the date.