### PR TITLE
Bug121 - Fix background color for month arrows

### DIFF
--- a/src/Calendar.Plugin/Shared/Controls/DefaultHeaderSection.xaml
+++ b/src/Calendar.Plugin/Shared/Controls/DefaultHeaderSection.xaml
@@ -26,7 +26,7 @@
             <Frame
                 Grid.Column="0"
                 Padding="0"
-                BackgroundColor="White"
+                BackgroundColor="{Binding BackgroundColor}"
                 CornerRadius="18"
                 HasShadow="True"
                 HeightRequest="36"
@@ -61,7 +61,7 @@
             <Frame
                 Grid.Column="2"
                 Padding="0"
-                BackgroundColor="White"
+                BackgroundColor="{Binding BackgroundColor}"
                 CornerRadius="18"
                 HasShadow="True"
                 HeightRequest="36"
@@ -101,7 +101,7 @@
             <Frame
                 Grid.Column="0"
                 Padding="0"
-                BackgroundColor="White"
+                BackgroundColor="{Binding BackgroundColor}"
                 CornerRadius="18"
                 HasShadow="True"
                 HeightRequest="36"
@@ -136,7 +136,7 @@
             <Frame
                 Grid.Column="2"
                 Padding="0"
-                BackgroundColor="White"
+                BackgroundColor="{Binding BackgroundColor}"
                 CornerRadius="18"
                 HasShadow="True"
                 HeightRequest="36"


### PR DESCRIPTION
Bug121- Fixed the hard code background color on the Frames for the Month pre/next arrows so that it is bound to the BackgroundColor of the calendar.