### PR TITLE
Bug 124 - ShowMonthPicker, MonthLabelColor, and DaysTitleColor values…

### DIFF
--- a/src/Calendar.Plugin.Sample/SampleApp/Controls/CalendarHeader.xaml
+++ b/src/Calendar.Plugin.Sample/SampleApp/Controls/CalendarHeader.xaml
@@ -8,7 +8,7 @@
         Margin="0,2"
         Padding="0"
         HorizontalOptions="FillAndExpand"
-        IsVisible="{Binding ShowLayoutUnitPicker}"
+        IsVisible="{Binding ShowMonthPicker}"
         VerticalOptions="Start">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -52,7 +52,7 @@
             FontAttributes="Bold"
             FontSize="Medium"
             HorizontalOptions="Center"
-            TextColor="{Binding LayoutUnitLabelColor}"
+            TextColor="{Binding MonthLabelColor}"
             VerticalOptions="Center">
             <Label.FormattedText>
                 <FormattedString>

--- a/src/Calendar.Plugin.Sample/SampleApp/Views/SimplePage.xaml
+++ b/src/Calendar.Plugin.Sample/SampleApp/Views/SimplePage.xaml
@@ -3,11 +3,9 @@
     x:Class="SampleApp.Views.SimplePage"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:SampleApp.ViewModels"
     xmlns:plugin="clr-namespace:Xamarin.Plugin.Calendar.Controls;assembly=Xamarin.Plugin.Calendar"
-    x:Name="simpleCalendarPage"
-    mc:Ignorable="d">
+    x:Name="simpleCalendarPage">
     <ContentPage.ToolbarItems>
         <ToolbarItem Command="{Binding TodayCommand}" Text="Today" />
     </ContentPage.ToolbarItems>

--- a/src/Calendar.Plugin/Shared/Controls/Calendar.xaml
+++ b/src/Calendar.Plugin/Shared/Controls/Calendar.xaml
@@ -3,7 +3,8 @@
     x:Class="Xamarin.Plugin.Calendar.Controls.Calendar"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:controls="clr-namespace:Xamarin.Plugin.Calendar.Controls"
+    xmlns:controls="clr-namespace:Xamarin.Plugin.Calendar.Controls" 
+    x:DataType="controls:Calendar"
     x:Name="calendar">
     <Grid
         Padding="0,15,0,0"

--- a/src/Calendar.Plugin/Shared/Controls/DefaultHeaderSection.xaml
+++ b/src/Calendar.Plugin/Shared/Controls/DefaultHeaderSection.xaml
@@ -2,7 +2,9 @@
 <ContentView
     x:Class="Xamarin.Plugin.Calendar.Controls.DefaultHeaderSection"
     xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+    xmlns:controls="clr-namespace:Xamarin.Plugin.Calendar.Controls" 
+    x:DataType="controls:Calendar">
 
     <!--  TODO: Controls for circle buttons  -->
     <StackLayout
@@ -12,7 +14,7 @@
         VerticalOptions="FillAndExpand">
         <Grid
             HorizontalOptions="FillAndExpand"
-            IsVisible="{Binding ShowLayoutUnitPicker}"
+            IsVisible="{Binding ShowMonthPicker}"
             VerticalOptions="StartAndExpand">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
@@ -55,7 +57,7 @@
                 FontSize="Medium"
                 HorizontalOptions="Center"
                 Text="{Binding LayoutUnitText}"
-                TextColor="{Binding LayoutUnitLabelColor}"
+                TextColor="{Binding MonthLabelColor}"
                 VerticalOptions="Center" />
 
             <Frame

--- a/src/Calendar.Plugin/Shared/Controls/MonthDaysView.cs
+++ b/src/Calendar.Plugin/Shared/Controls/MonthDaysView.cs
@@ -675,10 +675,11 @@ namespace Xamarin.Plugin.Calendar.Controls
 
             _daysControl = CurrentViewLayoutEngine.GenerateLayout(
                 _dayViews,
-                DaysTitleHeight,
-                DaysTitleColor,
-                DaysTitleLabelStyle,
-                DayViewSize,
+                this,
+                nameof(DaysTitleHeight),
+                nameof(DaysTitleColor),
+                nameof(DaysTitleLabelStyle),
+                nameof(DayViewSize),
                 DayTappedCommand,
                 OnDayModelPropertyChanged);
 

--- a/src/Calendar.Plugin/Shared/Controls/ViewLayoutEngines/MonthViewEngine.cs
+++ b/src/Calendar.Plugin/Shared/Controls/ViewLayoutEngines/MonthViewEngine.cs
@@ -19,20 +19,22 @@ namespace Xamarin.Plugin.Calendar.Shared.Controls.ViewLayoutEngines
 
         public Grid GenerateLayout(
             List<DayView> dayViews,
-            double daysTitleHeight,
-            Color daysTitleColor,
-            Style daysTitleLabelStyle,
-            double dayViewSize,
+            object bindingContext,
+            string daysTitleHeightBindingName,
+            string daysTitleColorBindingName,
+            string daysTitleLabelStyleBindingName,
+            string dayViewSizeBindingName,
             ICommand dayTappedCommand,
             PropertyChangedEventHandler dayModelPropertyChanged
         )
         {
             var grid = GenerateWeekLayout(
                 dayViews,
-                daysTitleHeight,
-                daysTitleColor,
-                daysTitleLabelStyle,
-                dayViewSize,
+                bindingContext,
+                daysTitleHeightBindingName,
+                daysTitleColorBindingName,
+                daysTitleLabelStyleBindingName,
+                dayViewSizeBindingName,
                 dayTappedCommand,
                 dayModelPropertyChanged,
                 _monthNumberOfWeeks

--- a/src/Calendar.Plugin/Shared/Controls/ViewLayoutEngines/ViewLayoutBase.cs
+++ b/src/Calendar.Plugin/Shared/Controls/ViewLayoutEngines/ViewLayoutBase.cs
@@ -28,23 +28,28 @@ namespace Xamarin.Plugin.Calendar.Shared.Controls.ViewLayoutEngines
 
         protected Grid GenerateWeekLayout(
                 List<DayView> dayViews,
-                double daysTitleHeight,
-                Color daysTitleColor,
-                Style daysTitleLabelStyle,
-                double dayViewSize,
+                object bindingContext,
+                string daysTitleHeightBindingName,
+                string daysTitleColorBindingName,
+                string daysTitleLabelStyleBindingName,
+                string dayViewSizeBindingName,
                 ICommand dayTappedCommand,
                 PropertyChangedEventHandler dayModelPropertyChanged,
                 int numberOfWeeks
             )
         {
+            var rowDefinition = new RowDefinition()
+            {
+                BindingContext = bindingContext,
+            };
+            rowDefinition.SetBinding(RowDefinition.HeightProperty, daysTitleHeightBindingName);
+
             var grid = new Grid
             {
                 ColumnSpacing = 0d,
                 RowDefinitions = new RowDefinitionCollection()
                 {
-                    new RowDefinition(){
-                        Height = daysTitleHeight
-                    },
+                    rowDefinition,
                 }
             };
 
@@ -52,10 +57,12 @@ namespace Xamarin.Plugin.Calendar.Shared.Controls.ViewLayoutEngines
             {
                 var label = new Label()
                 {
-                    TextColor = daysTitleColor,
-                    Style = daysTitleLabelStyle,
                     HorizontalTextAlignment = TextAlignment.Center,
                 };
+                label.BindingContext = bindingContext;
+                label.SetBinding(Label.TextColorProperty, daysTitleColorBindingName);
+                label.SetBinding(Label.StyleProperty, daysTitleLabelStyleBindingName);
+
                 Grid.SetRow(label, 0);
                 Grid.SetColumn(label, i);
 
@@ -66,10 +73,12 @@ namespace Xamarin.Plugin.Calendar.Shared.Controls.ViewLayoutEngines
 
             for (int i = 1; i <= numberOfWeeks; i++)
             {
-                grid.RowDefinitions.Add(new RowDefinition()
+                rowDefinition = new RowDefinition()
                 {
-                    Height = dayViewSize,
-                });
+                    BindingContext = bindingContext,
+                };
+                rowDefinition.SetBinding(RowDefinition.HeightProperty, dayViewSizeBindingName);
+                grid.RowDefinitions.Add(rowDefinition);
 
                 for (int ii = 0; ii < 7; ii++)
                 {

--- a/src/Calendar.Plugin/Shared/Controls/ViewLayoutEngines/WeekViewEngine.cs
+++ b/src/Calendar.Plugin/Shared/Controls/ViewLayoutEngines/WeekViewEngine.cs
@@ -22,20 +22,22 @@ namespace Xamarin.Plugin.Calendar.Shared.Controls.ViewLayoutEngines
 
         public Grid GenerateLayout(
             List<DayView> dayViews,
-            double daysTitleHeight,
-            Color daysTitleColor,
-            Style daysTitleLabelStyle,
-            double dayViewSize,
+            object bindingContext,
+            string daysTitleHeightBindingName,
+            string daysTitleColorBindingName,
+            string daysTitleLabelStyleBindingName,
+            string dayViewSizeBindingName,
             ICommand dayTappedCommand,
             PropertyChangedEventHandler dayModelPropertyChanged
         )
         {
             var grid = GenerateWeekLayout(
                 dayViews,
-                daysTitleHeight,
-                daysTitleColor,
-                daysTitleLabelStyle,
-                dayViewSize,
+                bindingContext,
+                daysTitleHeightBindingName,
+                daysTitleColorBindingName,
+                daysTitleLabelStyleBindingName,
+                dayViewSizeBindingName,
                 dayTappedCommand,
                 dayModelPropertyChanged,
                 _numberOfWeeks

--- a/src/Calendar.Plugin/Shared/Interfaces/IViewLayoutEngine.cs
+++ b/src/Calendar.Plugin/Shared/Interfaces/IViewLayoutEngine.cs
@@ -11,10 +11,11 @@ namespace Xamarin.Plugin.Calendar.Shared.Interfaces
     {
         Grid GenerateLayout(
             List<DayView> dayViews,
-            double daysTitleHeight,
-            Color daysTitleColor,
-            Style daysTitleLabelStyle,
-            double dayViewSize,
+            object bindingContext,
+            string daysTitleHeightBindingName,
+            string daysTitleColorBindingName,
+            string daysTitleLabelStyleBindingName,
+            string dayViewSizeBindingName,
             ICommand dayTappedCommand,
             PropertyChangedEventHandler dayModelPropertyChanged
         );


### PR DESCRIPTION
… are not honored

Fixed the references to ShowLayoutUnitPicker and LayoutUnitLabelColor to reference ShowMonthPicker and MonthLabelColor  respectfully.

Changed IViewLayoutEngine.GenerateLayout to take in the bindings for the calendar properties so the individual controls can be bound to the referenced properties, so any runtime changes to those values will automatically be updated in the contained controls. This also fixed the DaysTitleColor issue.