### PR TITLE
Ensure that the GestureDetector is disposed

### DIFF
--- a/src/Calendar.Plugin/Android/SwipeAwareContainerRenderer.cs
+++ b/src/Calendar.Plugin/Android/SwipeAwareContainerRenderer.cs
@@ -5,74 +5,118 @@ using Xamarin.Plugin.Calendar.Android;
 using Xamarin.Plugin.Calendar.Controls;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
+using View = Xamarin.Forms.View;
 
 [assembly: ExportRenderer(typeof(SwipeAwareContainer), typeof(SwipeAwareContainerRenderer))]
 namespace Xamarin.Plugin.Calendar.Android
 {
-    internal class SwipeAwareContainerRenderer : ViewRenderer, GestureDetector.IOnGestureListener
+    internal class SwipeAwareContainerRenderer : ViewRenderer
     {
         private const int SwipeDistanceThreshold = 50;
         private const int SwipeVelocityThreshold = 20;
-        private readonly GestureDetector _gestureDetector;
+        private GestureDetector _gestureDetector;
+        private GestureDetector.IOnGestureListener _gestureListener;
+        private bool _isDisposed;
 
         public SwipeAwareContainerRenderer(Context context) : base(context)
         {
-            _gestureDetector = new GestureDetector(context, this);
+        }
+
+        protected override void OnElementChanged(ElementChangedEventArgs<View> e)
+        {
+            base.OnElementChanged(e);
+
+            if (e.OldElement != null)
+            {
+                DisposeGestureDetectorAndListener();
+            }
+
+            if (e.NewElement != null)
+            {
+                _gestureListener = new InnerGestureListener(Element as SwipeAwareContainer);
+                _gestureDetector = new GestureDetector(Context, _gestureListener);
+            }
         }
 
         public override bool OnInterceptTouchEvent(MotionEvent ev)
         {
+            if (_isDisposed)
+                return false;
+
             if (Element is SwipeAwareContainer element && !element.SwipeDetectionDisabled)
-                _gestureDetector.OnTouchEvent(ev);
+                _gestureDetector?.OnTouchEvent(ev);
 
             return base.OnInterceptTouchEvent(ev);
         }
 
-        public bool OnFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY)
+        protected override void Dispose(bool disposing)
         {
-            if (!(Element is SwipeAwareContainer element))
-                return false;
+            if (_isDisposed)
+                return;
 
-            float distanceX = e2.GetX() - e1.GetX();
-            float distanceY = e2.GetY() - e1.GetY();
+            _isDisposed = true;
 
-            if (Math.Abs(distanceX) > Math.Abs(distanceY))
+            if (disposing)
             {
-                if (Math.Abs(distanceX) > SwipeDistanceThreshold && Math.Abs(velocityX) > SwipeVelocityThreshold)
-                {
-                    if (distanceX > 0)
-                        element.OnSwipeRight();
-                    else
-                        element.OnSwipeLeft();
-
-                    return true;
-                }
-            }
-            else
-            {
-                if (Math.Abs(distanceY) > SwipeDistanceThreshold && Math.Abs(velocityY) > SwipeVelocityThreshold)
-                {
-                    if (distanceY > 0)
-                        element.OnSwipeDown();
-                    else
-                        element.OnSwipeUp();
-
-                    return true;
-                }
+                DisposeGestureDetectorAndListener();
             }
 
-            return false;
+            base.Dispose(disposing);
         }
 
-        #region Unused gestures
+        private void DisposeGestureDetectorAndListener()
+        {
+            _gestureDetector?.Dispose();
+            _gestureDetector = null;
 
-        public bool OnDown(MotionEvent e) => false;
-        public void OnLongPress(MotionEvent e) { }
-        public bool OnScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) => false;
-        public void OnShowPress(MotionEvent e) { }
-        public bool OnSingleTapUp(MotionEvent e) => false;
+            _gestureListener?.Dispose();
+            _gestureListener = null;
+        }
 
-        #endregion
+        private class InnerGestureListener : GestureDetector.SimpleOnGestureListener
+        {
+            private SwipeAwareContainer SwipeAwareContainer { get; }
 
+            public InnerGestureListener(SwipeAwareContainer swipeAwareContainer)
+            {
+                SwipeAwareContainer = swipeAwareContainer;
+            }
+
+            public override bool OnFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY)
+            {
+                if (SwipeAwareContainer == null)
+                    return false;
+
+                float distanceX = e2.GetX() - e1.GetX();
+                float distanceY = e2.GetY() - e1.GetY();
+
+                if (Math.Abs(distanceX) > Math.Abs(distanceY))
+                {
+                    if (Math.Abs(distanceX) > SwipeDistanceThreshold && Math.Abs(velocityX) > SwipeVelocityThreshold)
+                    {
+                        if (distanceX > 0)
+                            SwipeAwareContainer.OnSwipeRight();
+                        else
+                            SwipeAwareContainer.OnSwipeLeft();
+
+                        return true;
+                    }
+                }
+                else
+                {
+                    if (Math.Abs(distanceY) > SwipeDistanceThreshold && Math.Abs(velocityY) > SwipeVelocityThreshold)
+                    {
+                        if (distanceY > 0)
+                            SwipeAwareContainer.OnSwipeDown();
+                        else
+                            SwipeAwareContainer.OnSwipeUp();
+
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
I received a log from a crash of my app that is related to the SwipeAwareContainerRenderer class used by the calendar.
From the stacktrace the crash seem to be caused by a press that try to access the renderer, but it has already been disposed so it crash the application.
This PR make two things : 
1. Ensure that the the gesture detector is disposed correctly like in #115
2. Decouple the renderer from the gesture listener because the two have not the same lifecycle, by doing this we ensure that the gesture listener is disposed before the renderer which is not garanted when the renderer is itself the gesture listener

FYI, the stacktrace of the crash
```cs
System.NotSupportedException: Unable to activate instance of type Xamarin.Plugin.Calendar.Android.SwipeAwareContainerRenderer from native handle 0xffc46fdc (key_handle 0xe4b6c0a).
  at IJavaPeerable Java.Interop.TypeManager.CreateInstance(IntPtr handle, JniHandleOwnership transfer, Type targetType)
  at IJavaPeerable Java.Lang.Object.GetObject(IntPtr handle, JniHandleOwnership transfer, Type type)
  at IOnGestureListener Java.Lang.Object._GetObject<IOnGestureListener>(IntPtr handle, JniHandleOwnership transfer)
  at IOnGestureListener Java.Lang.Object.GetObject<IOnGestureListener>(IntPtr handle, JniHandleOwnership transfer) x 2
  at void Android.Views.GestureDetector+IOnGestureListenerInvoker.n_OnLongPress_Landroid_view_MotionEvent_(IntPtr jnienv, IntPtr native__this, IntPtr native_e)
--- End of inner exception stack trace ---
  System.MissingMethodException: No constructor found for Xamarin.Plugin.Calendar.Android.SwipeAwareContainerRenderer::.ctor(System.IntPtr, Android.Runtime.JniHandleOwnership)
    at object Java.Interop.TypeManager.CreateProxy(Type type, IntPtr handle, JniHandleOwnership transfer)
    at IJavaPeerable Java.Interop.TypeManager.CreateInstance(IntPtr handle, JniHandleOwnership transfer, Type targetType)
```